### PR TITLE
#8 - Add the ability to use multiple port numbers as suffixes to url. With…

### DIFF
--- a/website-warmup/website-warmup.ps1
+++ b/website-warmup/website-warmup.ps1
@@ -96,6 +96,8 @@ if(-not $suffixes) {
 ($suffixes -split '[\r\n]') | ForEach-Object{
     if($_.StartsWith("/","CurrentCultureIgnoreCase")){
         $url = $rootUrl+$_;
+    } elseif($_.StartsWith(":","CurrentCultureIgnoreCase")){
+        $url = $rootUrl+$_;
     } else {
         $url = $rootUrl+"/" + $_;
     }


### PR DESCRIPTION
#8 
…out this fix a port number as suffix becomes "example.com/:8152" instead of desired "example.com:8152".